### PR TITLE
Add import to config_flow.py

### DIFF
--- a/custom_components/nad/config_flow.py
+++ b/custom_components/nad/config_flow.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.selector import (
 )
 from nad_receiver import NADReceiver, NADReceiverTCP, NADReceiverTelnet
 
-from . import NADReceiverCoordinator
+from . import NADReceiverCoordinator, CommandNotSupportedError
 from .const import (
     CONF_DEFAULT_MAX_VOLUME,
     CONF_DEFAULT_MIN_VOLUME,


### PR DESCRIPTION
CommandNotSupportedError doesn't seem to have been imported here.

This should fix part of rrooggiieerr/homeassistant-nad#3.