### PR TITLE
Fix serial port startup

### DIFF
--- a/custom_components/nad/config_flow.py
+++ b/custom_components/nad/config_flow.py
@@ -191,11 +191,10 @@ class NADReceiverConfigFlow(ConfigFlow, domain=DOMAIN):
             # Test if we can connect to the device and get model
             try:
                 receiver = NADReceiver(serial_port)
-                model = self.exec_command("Main.Model", "?")
+                model = receiver.main_model("?")
             except (serial.SerialException, CommandNotSupportedError):
                 errors["base"] = "cannot_connect"
             else:
-                model = receiver.main_model("?")
                 assert model is not None, "Failed to retrieve receiver model"
 
                 _LOGGER.info("Device %s available", serial_port)


### PR DESCRIPTION
Still trying to fix the logic error in #3.

I'm not sure why it called `self.exec_command("Main.Model", "?")` first here.  The method `exec_command` doesn't exist on `self` here, and the `receiver.main_model("?")` call does some lookups and eventually ends up just making a "Main.Model", "?" serial call itself, anyway.

Let's make the `main_model("?")` call once, and use its response (return value or exception) for both of the tests we need.  Plus, all the symbols exist at this point, so it shouldn't automatically fail.